### PR TITLE
Improve CLI for log tracer

### DIFF
--- a/src/emqx_mgmt_cli.erl
+++ b/src/emqx_mgmt_cli.erl
@@ -535,31 +535,37 @@ mnesia(_) ->
 %% @doc Trace Command
 
 trace(["list"]) ->
-    foreach(fun({{Who, Name}, LogFile}) ->
-                ?PRINT("trace ~s ~s -> ~s~n", [Who, Name, LogFile])
+    foreach(fun({{Who, Name}, {Level, LogFile}}) ->
+                ?PRINT("Trace(~s=~s, level=~s, destination=~p)~n", [Who, Name, Level, LogFile])
             end, emqx_tracer:lookup_traces());
 
-trace(["client", ClientId, "off"]) ->
+trace(["stop", "client", ClientId]) ->
     trace_off(client_id, ClientId);
 
-trace(["client", ClientId, LogFile]) ->
-    trace_on(client_id, ClientId, LogFile);
+trace(["start", "client", ClientId, LogFile]) ->
+    trace_on(client_id, ClientId, all, LogFile);
 
-trace(["topic", Topic, "off"]) ->
+trace(["start", "client", ClientId, Level, LogFile]) ->
+    trace_on(client_id, ClientId, Level, LogFile);
+
+trace(["stop", "topic", Topic]) ->
     trace_off(topic, Topic);
 
-trace(["topic", Topic, LogFile]) ->
-    trace_on(topic, Topic, LogFile);
+trace(["start", "topic", Topic, LogFile]) ->
+    trace_on(topic, Topic, all, LogFile);
+
+trace(["start", "topic", Topic, Level, LogFile]) ->
+    trace_on(topic, Topic, Level, LogFile);
 
 trace(_) ->
-    emqx_cli:usage([{"trace list",                       "List all traces"},
-                    {"trace client <ClientId> <LogFile>","Trace a client by client_id"},
-                    {"trace client <ClientId> off",      "Stop tracing a client by client_id"},
-                    {"trace topic <Topic> <LogFile>",    "Trace a topic"},
-                    {"trace topic <Topic> off",          "Stop tracing a Topic"}]).
+    emqx_cli:usage([{"trace list", "List all traces started"},
+                    {"trace start client <ClientId> [<Level>] <File>", "Trace logs related to a client_id"},
+                    {"trace stop client  <ClientId>", "Stop tracing a client by client_id"},
+                    {"trace start topic  <Topic> [<Level>] <File>", "Trace logs related to a topic"},
+                    {"trace stop topic   <Topic> ", "Stop tracing for a topic"}]).
 
-trace_on(Who, Name, LogFile) ->
-    case emqx_tracer:start_trace({Who, iolist_to_binary(Name)}, LogFile) of
+trace_on(Who, Name, Level, LogFile) ->
+    case emqx_tracer:start_trace({Who, iolist_to_binary(Name)}, Level, LogFile) of
         ok ->
             emqx_cli:print("trace ~s ~s successfully.~n", [Who, Name]);
         {error, Error} ->

--- a/src/emqx_mgmt_cli.erl
+++ b/src/emqx_mgmt_cli.erl
@@ -560,9 +560,9 @@ trace(["start", "topic", Topic, Level, LogFile]) ->
 trace(_) ->
     emqx_cli:usage([{"trace list", "List all traces started"},
                     {"trace start client <ClientId> [<Level>] <File>", "Trace logs related to a client_id"},
-                    {"trace stop client  <ClientId>", "Stop tracing a client by client_id"},
-                    {"trace start topic  <Topic> [<Level>] <File>", "Trace logs related to a topic"},
-                    {"trace stop topic   <Topic> ", "Stop tracing for a topic"}]).
+                    {"trace stop  client <ClientId>", "Stop tracing a client by client_id"},
+                    {"trace start topic  <Topic>    [<Level>] <File>", "Trace logs related to a topic"},
+                    {"trace stop  topic  <Topic> ", "Stop tracing for a topic"}]).
 
 trace_on(Who, Name, Level, LogFile) ->
     case emqx_tracer:start_trace({Who, iolist_to_binary(Name)}, Level, LogFile) of

--- a/src/emqx_mgmt_cli.erl
+++ b/src/emqx_mgmt_cli.erl
@@ -545,8 +545,8 @@ trace(["stop", "client", ClientId]) ->
 trace(["start", "client", ClientId, LogFile]) ->
     trace_on(client_id, ClientId, all, LogFile);
 
-trace(["start", "client", ClientId, Level, LogFile]) ->
-    trace_on(client_id, ClientId, Level, LogFile);
+trace(["start", "client", ClientId, LogFile, Level]) ->
+    trace_on(client_id, ClientId, list_to_atom(Level), LogFile);
 
 trace(["stop", "topic", Topic]) ->
     trace_off(topic, Topic);
@@ -554,30 +554,30 @@ trace(["stop", "topic", Topic]) ->
 trace(["start", "topic", Topic, LogFile]) ->
     trace_on(topic, Topic, all, LogFile);
 
-trace(["start", "topic", Topic, Level, LogFile]) ->
-    trace_on(topic, Topic, Level, LogFile);
+trace(["start", "topic", Topic, LogFile, Level]) ->
+    trace_on(topic, Topic, list_to_atom(Level), LogFile);
 
 trace(_) ->
     emqx_cli:usage([{"trace list", "List all traces started"},
-                    {"trace start client <ClientId> [<Level>] <File>", "Trace logs related to a client_id"},
-                    {"trace stop  client <ClientId>", "Stop tracing a client by client_id"},
-                    {"trace start topic  <Topic>    [<Level>] <File>", "Trace logs related to a topic"},
+                    {"trace start client <ClientId> <File> [<Level>]", "Traces for a client"},
+                    {"trace stop  client <ClientId>", "Stop tracing for a client"},
+                    {"trace start topic  <Topic>    <File> [<Level>] ", "Traces for a topic"},
                     {"trace stop  topic  <Topic> ", "Stop tracing for a topic"}]).
 
 trace_on(Who, Name, Level, LogFile) ->
     case emqx_tracer:start_trace({Who, iolist_to_binary(Name)}, Level, LogFile) of
         ok ->
-            emqx_cli:print("trace ~s ~s successfully.~n", [Who, Name]);
+            emqx_cli:print("trace ~s ~s successfully~n", [Who, Name]);
         {error, Error} ->
-            emqx_cli:print("trace ~s ~s error: ~p~n", [Who, Name, Error])
+            emqx_cli:print("[error] trace ~s ~s: ~p~n", [Who, Name, Error])
     end.
 
 trace_off(Who, Name) ->
     case emqx_tracer:stop_trace({Who, iolist_to_binary(Name)}) of
         ok ->
-            emqx_cli:print("stop tracing ~s ~s successfully.~n", [Who, Name]);
+            emqx_cli:print("stop tracing ~s ~s successfully~n", [Who, Name]);
         {error, Error} ->
-            emqx_cli:print("stop tracing ~s ~s error: ~p.~n", [Who, Name, Error])
+            emqx_cli:print("[error] stop tracing ~s ~s: ~p~n", [Who, Name, Error])
     end.
 
 %%--------------------------------------------------------------------


### PR DESCRIPTION
### CLI
```shell
--------------------------------------------------------------------------------
trace list                                      # List all traces started
trace start client <ClientId> <File> [<Level>]  # Trace logs related to a client_id
trace stop client  <ClientId>                   # Stop tracing a client by client_id
trace start topic  <Topic>    <File> [<Level>]  # Trace logs related to a topic
trace stop topic   <Topic>                      # Stop tracing for a topic
--------------------------------------------------------------------------------
```

### Trace Examples

```shell
## change the primary log level to all
## this is important before tracing logs
$ emqx_ctl log primary-level all
ok

## start tracing logs related to clientid 'client1', and redirect the messages
## to '/tmp/client1.log'
$ emqx_ctl trace start client 'client1' '/tmp/client1.log'
ok

## same to above, expect that only trace messages higher than error
$ emqx_ctl trace start client 'client1' '/tmp/client1.log' error
ok

## start tracing logs related to topic filter 'topic1/#', and redirect the messages
## to '/tmp/topic1.log'. wildcard is supported.
$ emqx_ctl trace start topic 'topic1/#' '/tmp/topic1.log'
ok
```
