### PR TITLE
Add optional secret argument for application creation

### DIFF
--- a/src/emqx_mgmt_cli.erl
+++ b/src/emqx_mgmt_cli.erl
@@ -58,7 +58,17 @@ is_cmd(Fun) ->
     not lists:member(Fun, [init, load, module_info]).
 
 mgmt(["insert", AppId, Name]) ->
-    case emqx_mgmt_auth:add_app(list_to_binary(AppId), list_to_binary(Name)) of
+    case emqx_mgmt_auth:add_app(list_to_binary(AppId), list_to_binary(Name), undefined) of
+        {ok, Secret} ->
+            emqx_cli:print("AppSecret: ~s~n", [Secret]);
+        {error, already_existed} ->
+            emqx_cli:print("Error: already existed~n");
+        {error, Reason} ->
+            emqx_cli:print("Error: ~p~n", [Reason])
+    end;
+
+mgmt(["insert", AppId, Name, Secret]) ->
+    case emqx_mgmt_auth:add_app(list_to_binary(AppId), list_to_binary(Name), list_to_binary(Secret)) of
         {ok, Secret} ->
             emqx_cli:print("AppSecret: ~s~n", [Secret]);
         {error, already_existed} ->
@@ -101,7 +111,7 @@ mgmt(["list"]) ->
 
 mgmt(_) ->
     emqx_cli:usage([{"mgmt list",                   "List Applications"},
-                    {"mgmt insert <AppId> <Name>",   "Add Application of REST API"},
+                    {"mgmt insert <AppId> <Name> [<Secret>]",   "Add Application of REST API"},
                     {"mgmt update <AppId> <status>", "Update Application of REST API"},
                     {"mgmt lookup <AppId>",          "Get Application of REST API"},
                     {"mgmt delete <AppId>",          "Delete Application of REST API"}]).

--- a/test/emq_mgmt_SUITE.erl
+++ b/test/emq_mgmt_SUITE.erl
@@ -45,14 +45,27 @@ end_per_suite(_Config) ->
     application:stop(mnesia).
 
 t_add_app(_Config) ->
-    {ok, AppSecret} = emqx_mgmt_auth:add_app(<<"app_id">>, <<"app_name">>),
-    ?assert(emqx_mgmt_auth:is_authorized(<<"app_id">>, AppSecret)),
-    ?assertEqual(AppSecret, emqx_mgmt_auth:get_appsecret(<<"app_id">>)),
-    ?assertEqual([{<<"app_id">>, AppSecret,
-                   <<"app_name">>, <<"Application user">>, 
-                   true, undefined}], 
+    {ok, AppSecretManual} = emqx_mgmt_auth:add_app(<<"app_id">>, <<"app_name">>, <<"manual_password">>),
+    ?assert(emqx_mgmt_auth:is_authorized(<<"app_id">>, <<"manual_password">>)),
+    ?assertEqual(AppSecretManual, <<"manual_password">>),
+    ?assertEqual(AppSecretManual, emqx_mgmt_auth:get_appsecret(<<"app_id">>)),
+    ?assertEqual([{<<"app_id">>, AppSecretManual,
+                   <<"app_name">>, <<"Application user">>,
+                   true, undefined}],
                  emqx_mgmt_auth:list_apps()),
     emqx_mgmt_auth:del_app(<<"app_id">>),
+
+    {ok, AppSecretGenerated} = emqx_mgmt_auth:add_app(<<"app_id">>, <<"app_name">>, undefined),
+    ?assert(emqx_mgmt_auth:is_authorized(<<"app_id">>, AppSecretGenerated)),
+    ?assertNotEqual(undefined, emqx_mgmt_auth:get_appsecret(<<"app_id">>)),
+    ?assertEqual(string:length(AppSecretGenerated), 47),
+    ?assertEqual(AppSecretGenerated, emqx_mgmt_auth:get_appsecret(<<"app_id">>)),
+    ?assertEqual([{<<"app_id">>, AppSecretGenerated,
+                   <<"app_name">>, <<"Application user">>,
+                   true, undefined}],
+                 emqx_mgmt_auth:list_apps()),
+    emqx_mgmt_auth:del_app(<<"app_id">>),
+
     ok.
 
 t_del_app(_Config) ->


### PR DESCRIPTION
Make possible to create application with pregenerated password which is
very useful for automated deployments and tests where password is
securely generated and stored outside single service scope.