### PR TITLE
Fix bug when updating plugin's config by dashboard

### DIFF
--- a/src/emqx_mgmt_api_configs.erl
+++ b/src/emqx_mgmt_api_configs.erl
@@ -99,10 +99,11 @@ update_plugin_configs(#{node := Node, plugin := Plugin}, Params) ->
 
 ensure_reload_plugin(Plugin) ->
     case lists:keyfind(Plugin, 2, emqx_plugins:list()) of
-        {_, _, _, _, true} ->
+        #plugin{active = true} ->
             emqx_plugins:unload(Plugin),
             timer:sleep(500),
-            emqx_plugins:load(Plugin);
+            {ok, _StartedApps} = emqx_plugins:load(Plugin),
+            ok;
          _ ->
             ok
     end.


### PR DESCRIPTION
Description: 
Fix the bug that module can't reload plugin after updating config because of incorrect match