### PR TITLE
Fix emqx_management project for travis CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,9 @@ LOCAL_DEPS = mnesia
 CUR_BRANCH := $(shell git branch | grep -e "^*" | cut -d' ' -f 2)
 BRANCH := $(if $(filter $(CUR_BRANCH), master develop), $(CUR_BRANCH), develop)
 
-BUILD_DEPS = emqx cuttlefish
+BUILD_DEPS = emqx cuttlefish emqx_reloader
 dep_emqx = git-emqx https://github.com/emqx/emqx $(BRANCH)
 dep_cuttlefish = git-emqx https://github.com/emqx/cuttlefish v2.2.1
-
-TEST_DEPS = emqx_reloader
 dep_emqx_reloader = git-emqx https://github.com/emqx/emqx-reloader $(BRANCH)
 
 NO_AUTOPATCH = cuttlefish

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,12 @@ LOCAL_DEPS = mnesia
 CUR_BRANCH := $(shell git branch | grep -e "^*" | cut -d' ' -f 2)
 BRANCH := $(if $(filter $(CUR_BRANCH), master develop), $(CUR_BRANCH), develop)
 
-BUILD_DEPS = emqx cuttlefish emqx_reloader
+BUILD_DEPS = emqx cuttlefish
 dep_emqx = git-emqx https://github.com/emqx/emqx $(BRANCH)
 dep_cuttlefish = git-emqx https://github.com/emqx/cuttlefish v2.2.1
+
+
+TEST_DEPS = emqx_reloader
 dep_emqx_reloader = git-emqx https://github.com/emqx/emqx-reloader $(BRANCH)
 
 NO_AUTOPATCH = cuttlefish

--- a/etc/emqx_management.conf
+++ b/etc/emqx_management.conf
@@ -29,4 +29,3 @@ management.listener.http.send_timeout_close = on
 ## management.listener.https.cacertfile = etc/certs/cacert.pem
 ## management.listener.https.verify = verify_peer
 ## management.listener.https.fail_if_no_peer_cert = true
-

--- a/rebar.config
+++ b/rebar.config
@@ -3,7 +3,7 @@
         {clique, "v0.3.11"},
         {cuttlefish, "v2.2.1"}]}.
 
-{github_emqx_projects, [emqx]}.
+{github_emqx_projects, [emqx, emqx_reloader]}.
 
 {edoc_opts, [{preprocess, true}]}.
 {erl_opts, [warn_unused_vars,

--- a/rebar.config.script
+++ b/rebar.config.script
@@ -5,7 +5,7 @@ CONFIG0 = case os:getenv("REBAR_GIT_CLONE_OPTIONS") of
                   os:putenv("REBAR_GIT_CLONE_OPTIONS", "--depth 1"),
                   CONFIG
           end,
-
+ 
 CONFIG1 = case os:getenv("TRAVIS") of
               "true" ->
                   JobId = os:getenv("TRAVIS_JOB_ID"),
@@ -15,35 +15,37 @@ CONFIG1 = case os:getenv("TRAVIS") of
               _ ->
                   CONFIG
           end,
-
+ 
 CUR_BRANCH = os:cmd("git branch | grep -e '^*' | cut -d' ' -f 2") -- "\n",
-
-BRANCH = case lists:member(CUR_BRANCH, ["master", "develop", "testing"]) of
+ 
+BRANCH = case lists:member(CUR_BRANCH, ["master", "develop"]) of
              true -> CUR_BRANCH;
-             false -> "testing"
+             false -> "develop"
          end,
-
-Deps = case lists:keyfind(deps, 1, CONFIG1) of
-           {_, RawDeps} -> RawDeps;
-           _ -> []
-       end,
-
-{_, LibDeps} = lists:keyfind(github_emqx_libs, 1, CONFIG1),
-{_, ProjDeps} = lists:keyfind(github_emqx_projects, 1, CONFIG1),
+ 
+FindDeps = fun(DepsType, Config) ->
+                   case lists:keyfind(DepsType, 1, Config) of
+                       {_, RawDeps} -> RawDeps;
+                       _ -> []
+                   end
+           end,
+Deps = FindDeps(deps, CONFIG1),
+LibDeps = FindDeps(github_emqx_libs, CONFIG1),
+ProjDeps = FindDeps(github_emqx_projects, CONFIG1),
 UrlPrefix = "https://github.com/emqx/",
 RealName = fun TransName([$_ | Tail], Result) ->
-                       TransName(Tail, [$- | Result]);
-                   TransName([Head | Tail], Result) ->
-                       TransName(Tail, [Head | Result]);
-                   TransName([], Result) ->
-                       lists:reverse(Result)
+                   TransName(Tail, [$- | Result]);
+               TransName([Head | Tail], Result) ->
+                   TransName(Tail, [Head | Result]);
+               TransName([], Result) ->
+                   lists:reverse(Result)
            end,
-
-NewLibDeps = [{LibName, {git, UrlPrefix ++ RealName(atom_to_list(LibName), []), {branch, Branch}}} || {LibName, Branch} <- LibDeps],
-NewProjDeps = Deps ++ [{Name, {git, UrlPrefix ++ RealName(atom_to_list(Name), []), {branch, BRANCH}}}
-                  || Name <- ProjDeps],
+ 
+NewLibDeps = [{LibName, {git, UrlPrefix ++ RealName(atom_to_list(LibName), []), {branch, Branch}}}
+              || {LibName, Branch} <- LibDeps],
+NewProjDeps = [{Name, {git, UrlPrefix ++ RealName(atom_to_list(Name), []), {branch, BRANCH}}}
+                           || Name <- ProjDeps],
 
 NewDeps = Deps ++ NewLibDeps ++ NewProjDeps,
-
 CONFIG2 = lists:keystore(deps, 1, CONFIG1, {deps, NewDeps}),
 CONFIG2.

--- a/src/emqx_mgmt.erl
+++ b/src/emqx_mgmt.erl
@@ -177,6 +177,7 @@ kickout_conn(ClientId) ->
 kickout_conn(Node, ClientId) when Node =:= node() ->
     Cpid = emqx_cm:lookup_conn_pid(ClientId),
     case emqx_cm:get_conn_attrs(ClientId, Cpid) of
+        [] -> {error, not_found};
         Attrs ->
             Module = proplists:get_value(conn_mod, Attrs),
             Module:kick(Cpid)

--- a/src/emqx_mgmt.erl
+++ b/src/emqx_mgmt.erl
@@ -60,8 +60,7 @@
 
 %% Banned
 -export([create_banned/1,
-         delete_banned/1
-        ]).
+         delete_banned/1]).
 
 %% Common Table API
 -export([count/1, tables/1, query_handle/1, item/2, max_row_limit/0]).

--- a/src/emqx_mgmt.erl
+++ b/src/emqx_mgmt.erl
@@ -30,7 +30,7 @@
 
 %% Clients, Sessions
 -export([list_conns/1, lookup_conn/2, lookup_conn/3,
-         kickout_conn/1, kickout_conn/2, clean_acl_cache/2, clean_acl_cache/3]).
+         kickout_conn/1, kickout_conn/2]).
 
 -export([list_sessions/1, lookup_session/1, lookup_session/2]).
 
@@ -180,28 +180,27 @@ kickout_conn(Node, ClientId) when Node =:= node() ->
     case emqx_cm:get_conn_attrs(ClientId, Cpid) of
         Attrs ->
             Module = proplists:get_value(conn_mod, Attrs),
-            Module:kick(Cpid);
-        [] -> {error, not_found}
+            Module:kick(Cpid)
     end;
 
 kickout_conn(Node, ClientId) ->
     rpc_call(Node, kickout_conn, [Node, ClientId]).
 
-clean_acl_cache(ClientId, Topic) ->
-    Results = [clean_acl_cache(Node, ClientId, Topic) || Node <- ekka_mnesia:running_nodes()],
-    case lists:any(fun(Item) -> Item =:= ok end, Results) of
-        true  -> ok;
-        false -> lists:last(Results)
-    end.
+%% clean_acl_cache(ClientId, Topic) ->
+%%     Results = [clean_acl_cache(Node, ClientId, Topic) || Node <- ekka_mnesia:running_nodes()],
+%%     case lists:any(fun(Item) -> Item =:= ok end, Results) of
+%%         true  -> ok;
+%%         false -> lists:last(Results)
+%%     end.
 
-clean_acl_cache(Node, ClientId, Topic) when Node =:= node() ->
-    case emqx_cm:lookup_conn_pid(ClientId) of
-        Pid when is_pid(Pid) ->
-            emqx_connection:clean_acl_cache(Pid, Topic);
-        _ -> {error, not_found}
-    end;
-clean_acl_cache(Node, ClientId, Topic) ->
-    rpc_call(Node, clean_acl_cache, [Node, ClientId, Topic]).
+%% clean_acl_cache(Node, ClientId, Topic) when Node =:= node() ->
+%%     case emqx_cm:lookup_conn_pid(ClientId) of
+%%         Pid when is_pid(Pid) ->
+%%             emqx_connection:clean_acl_cache(Pid, Topic);
+%%         _ -> {error, not_found}
+%%     end;
+%% clean_acl_cache(Node, ClientId, Topic) ->
+%%     rpc_call(Node, clean_acl_cache, [Node, ClientId, Topic]).
 
 %%--------------------------------------------------------------------
 %% Sessions

--- a/src/emqx_mgmt_app.erl
+++ b/src/emqx_mgmt_app.erl
@@ -25,5 +25,5 @@ start(_Type, _Args) ->
     {ok, Sup}.
 
 stop(_State) ->
-    emqx_mgmt_http:stop_listeners().
-    %% emqx_mgmt_cli:unload().
+    emqx_mgmt_http:stop_listeners(),
+    emqx_mgmt_cli:unload().

--- a/src/emqx_mgmt_app.erl
+++ b/src/emqx_mgmt_app.erl
@@ -25,6 +25,5 @@ start(_Type, _Args) ->
     {ok, Sup}.
 
 stop(_State) ->
-    emqx_mgmt_http:stop_listeners(),
-    emqx_mgmt_cli:unload().
-
+    emqx_mgmt_http:stop_listeners().
+    %% emqx_mgmt_cli:unload().

--- a/src/emqx_mgmt_cli.erl
+++ b/src/emqx_mgmt_cli.erl
@@ -581,24 +581,6 @@ log(_) ->
                     {"log handlers list", "Show log handlers"},
                     {"log handlers set-level <HandlerId> <Level>", "Set log level of a log handler"}]).
 
-set_handlers_level([{ID, Level, _Dst} | List], NewLevel) ->
-    set_handlers_level([{ID, Level, _Dst} | List], NewLevel, []).
-
-set_handlers_level([{ID, Level, _Dst} | List], NewLevel, ChangeHistory) ->
-    case emqx_logger:set_log_handler_level(ID, list_to_atom(NewLevel)) of
-        ok -> set_handlers_level(List, NewLevel, [{ID, Level} | ChangeHistory]);
-        {error, Error} ->
-            emqx_cli:print("[error] set level for handler ~p failed: ~p~n", [ID, Error]),
-            rollback(ChangeHistory)
-    end;
-set_handlers_level([], _NewLevel, _NewHanlder) ->
-    emqx_cli:print("~s~n", [ok]).
-
-rollback([{ID, Level} | List]) ->
-    emqx_logger:set_log_handler_level(ID, list_to_atom(Level)),
-    rollback(List);
-rollback([]) -> ok.
-
 %%--------------------------------------------------------------------
 %% @doc Trace Command
 

--- a/src/emqx_mgmt_cli.erl
+++ b/src/emqx_mgmt_cli.erl
@@ -23,7 +23,7 @@
 
 -import(proplists, [get_value/2]).
 
--export([load/0]).
+-export([load/0, unload/0]).
 
 -export([status/1, broker/1, cluster/1, clients/1, sessions/1,
          routes/1, subscriptions/1, plugins/1, bridges/1,
@@ -46,6 +46,11 @@ load() ->
     Cmds = [Fun || {Fun, _} <- ?MODULE:module_info(exports), is_cmd(Fun)],
     lists:foreach(fun(Cmd) -> emqx_ctl:register_command(Cmd, {?MODULE, Cmd}, []) end, Cmds),
     emqx_mgmt_cli_cfg:register_config().
+
+-spec(unload() -> ok).
+unload() ->
+    Cmds = [Fun || {Fun, _} <- ?MODULE:module_info(exports), is_cmd(Fun)],
+    lists:foreach(fun(Cmd) -> emqx_ctl:unregister_command(Cmd) end, Cmds).
 
 is_cmd(Fun) ->
     not lists:member(Fun, [init, load, module_info]).

--- a/src/emqx_mgmt_cli_cfg.erl
+++ b/src/emqx_mgmt_cli_cfg.erl
@@ -83,17 +83,17 @@ register_config_cli() ->
     register_protocol_formatter(),
     register_client_formatter(),
     register_session_formatter(),
-    register_queue_formatter(),
-    register_lager_formatter(),
+    %% register_queue_formatter(),
+    %% register_lager_formatter(),
 
     register_auth_config(),
-    register_protocol_config(),
+    %% register_protocol_config(),
     register_connection_config(),
-    register_client_config(),
-    register_session_config(),
-    register_queue_config(),
-    register_broker_config(),
-    register_lager_config().
+    %% register_client_config(),
+    %% register_session_config(),
+    %% register_queue_config(),
+    register_broker_config().
+    %% register_lager_config().
 
 set_usage() ->
     io:format("~-40s# ~-20s# ~-20s ~p~n", ["key", "value", "datatype", "app"]),
@@ -152,8 +152,8 @@ register_auth_config() ->
                   "mqtt.acl_nomatch",
                   "mqtt.acl_file",
                   "mqtt.cache_acl"],
-    [clique:register_config(Key , fun auth_config_callback/2) || Key <- ConfigKeys],
-    ok = register_config_whitelist(ConfigKeys).
+    [clique:register_config(Key , fun auth_config_callback/2) || Key <- ConfigKeys].
+    %% ok = register_config_whitelist(ConfigKeys).
 
 auth_config_callback([_, KeyStr], Value) ->
     application:set_env(?APP, l2a(KeyStr), Value), " successfully\n".
@@ -167,30 +167,31 @@ register_protocol_formatter() ->
                   "max_packet_size",
                   "websocket_protocol_header",
                   "keepalive_backoff"],
-    [clique:register_formatter(["mqtt", Key], fun protocol_formatter_callback/2) || Key <- ConfigKeys].
+    [clique:register_formatter(["mqtt", Key], fun protocol_formatter_callback/2) 
+     || Key <- ConfigKeys].
 
 protocol_formatter_callback([_, "websocket_protocol_header"], Params) ->
     Params;
 protocol_formatter_callback([_, Key], Params) ->
     proplists:get_value(l2a(Key), Params).
 
-register_protocol_config() ->
-    ConfigKeys = ["mqtt.max_clientid_len",
-                  "mqtt.max_packet_size",
-                  "mqtt.websocket_protocol_header",
-                  "mqtt.keepalive_backoff"],
-    [clique:register_config(Key , fun protocol_config_callback/2) || Key <- ConfigKeys],
-    ok = register_config_whitelist(ConfigKeys).
+%% register_protocol_config() ->
+%%     ConfigKeys = ["mqtt.max_clientid_len",
+%%                   "mqtt.max_packet_size",
+%%                   "mqtt.websocket_protocol_header",
+%%                   "mqtt.keepalive_backoff"],
+%%     [clique:register_config(Key , fun protocol_config_callback/2) || Key <- ConfigKeys].
+%%     ok = register_config_whitelist(ConfigKeys).
 
-protocol_config_callback([_AppStr, KeyStr], Value) ->
-    protocol_config_callback(protocol, l2a(KeyStr), Value).
-protocol_config_callback(_App, websocket_protocol_header, Value) ->
-    application:set_env(?APP, websocket_protocol_header, Value),
-    " successfully\n";
-protocol_config_callback(App, Key, Value) ->
-    {ok, Env} = emqx:env(App),
-    application:set_env(?APP, App, lists:keyreplace(Key, 1, Env, {Key, Value})),
-    " successfully\n".
+%% protocol_config_callback([_AppStr, KeyStr], Value) ->
+%%     protocol_config_callback(protocol, l2a(KeyStr), Value).
+%% protocol_config_callback(_App, websocket_protocol_header, Value) ->
+%%     application:set_env(?APP, websocket_protocol_header, Value),
+%%     " successfully\n";
+%% protocol_config_callback(App, Key, Value) ->
+%%     {ok, Env} = emqx:env(App),
+%%     application:set_env(?APP, App, lists:keyreplace(Key, 1, Env, {Key, Value})),
+%%     " successfully\n".
 
 %%--------------------------------------------------------------------
 %% MQTT Connection
@@ -198,8 +199,8 @@ protocol_config_callback(App, Key, Value) ->
 
 register_connection_config() ->
     ConfigKeys = ["mqtt.conn.force_gc_count"],
-    [clique:register_config(Key , fun connection_config_callback/2) || Key <- ConfigKeys],
-    ok = register_config_whitelist(ConfigKeys).
+    [clique:register_config(Key , fun connection_config_callback/2) || Key <- ConfigKeys].
+    %% ok = register_config_whitelist(ConfigKeys).
 
 connection_config_callback([_, KeyStr0, KeyStr1], Value) ->
     KeyStr = lists:concat([KeyStr0, "_", KeyStr1]),
@@ -219,28 +220,28 @@ register_client_formatter() ->
 client_formatter_callback([_, _, Key], Params) ->
     proplists:get_value(list_to_atom(Key), Params).
 
-register_client_config() ->
-    ConfigKeys = ["mqtt.client.max_publish_rate",
-                  "mqtt.client.idle_timeout",
-                  "mqtt.client.enable_stats"],
-    [clique:register_config(Key , fun client_config_callback/2) || Key <- ConfigKeys],
-    ok = register_config_whitelist(ConfigKeys).
+%% register_client_config() ->
+%%     ConfigKeys = ["mqtt.client.max_publish_rate",
+%%                   "mqtt.client.idle_timeout",
+%%                   "mqtt.client.enable_stats"],
+%%     [clique:register_config(Key , fun client_config_callback/2) || Key <- ConfigKeys],
+%%     ok = register_config_whitelist(ConfigKeys).
 
-client_config_callback([_, AppStr, KeyStr], Value) ->
-    client_config_callback(l2a(AppStr), l2a(KeyStr), Value).
+%% client_config_callback([_, AppStr, KeyStr], Value) ->
+%%     client_config_callback(l2a(AppStr), l2a(KeyStr), Value).
 
-client_config_callback(App, idle_timeout, Value) ->
-    {ok, Env} = emqx:env(App),
-    application:set_env(?APP, App, lists:keyreplace(client_idle_timeout, 1, Env, {client_idle_timeout, Value})),
-    " successfully\n";
-client_config_callback(App, enable_stats, Value) ->
-    {ok, Env} = emqx:env(App),
-    application:set_env(?APP, App, lists:keyreplace(client_enable_stats, 1, Env, {client_enable_stats, Value})),
-    " successfully\n";
-client_config_callback(App, Key, Value) ->
-    {ok, Env} = emqx:env(App),
-    application:set_env(?APP, App, lists:keyreplace(Key, 1, Env, {Key, Value})),
-    " successfully\n".
+%% client_config_callback(App, idle_timeout, Value) ->
+%%     {ok, Env} = emqx:env(App),
+%%     application:set_env(?APP, App, lists:keyreplace(client_idle_timeout, 1, Env, {client_idle_timeout, Value})),
+%%     " successfully\n";
+%% client_config_callback(App, enable_stats, Value) ->
+%%     {ok, Env} = emqx:env(App),
+%%     application:set_env(?APP, App, lists:keyreplace(client_enable_stats, 1, Env, {client_enable_stats, Value})),
+%%     " successfully\n";
+%% client_config_callback(App, Key, Value) ->
+%%     {ok, Env} = emqx:env(App),
+%%     application:set_env(?APP, App, lists:keyreplace(Key, 1, Env, {Key, Value})),
+%%     " successfully\n".
 
 %%--------------------------------------------------------------------
 %% session
@@ -261,25 +262,25 @@ register_session_formatter() ->
 session_formatter_callback([_, _, Key], Params) ->
     proplists:get_value(list_to_atom(Key), Params).
 
-register_session_config() ->
-    ConfigKeys = ["mqtt.session.max_subscriptions",
-                  "mqtt.session.upgrade_qos",
-                  "mqtt.session.max_inflight",
-                  "mqtt.session.retry_interval",
-                  "mqtt.session.max_awaiting_rel",
-                  "mqtt.session.await_rel_timeout",
-                  "mqtt.session.enable_stats",
-                  "mqtt.session.expiry_interval",
-                  "mqtt.session.ignore_loop_deliver"],
-    [clique:register_config(Key , fun session_config_callback/2) || Key <- ConfigKeys],
-    ok = register_config_whitelist(ConfigKeys).
+%% register_session_config() ->
+%%     ConfigKeys = ["mqtt.session.max_subscriptions",
+%%                   "mqtt.session.upgrade_qos",
+%%                   "mqtt.session.max_inflight",
+%%                   "mqtt.session.retry_interval",
+%%                   "mqtt.session.max_awaiting_rel",
+%%                   "mqtt.session.await_rel_timeout",
+%%                   "mqtt.session.enable_stats",
+%%                   "mqtt.session.expiry_interval",
+%%                   "mqtt.session.ignore_loop_deliver"],
+%%     [clique:register_config(Key , fun session_config_callback/2) || Key <- ConfigKeys].
+%%     ok = register_config_whitelist(ConfigKeys).
 
-session_config_callback([_, AppStr, KeyStr], Value) ->
-    session_config_callback(l2a(AppStr), l2a(KeyStr), Value).
-session_config_callback(App, Key, Value) ->
-    {ok, Env} = emqx:env(App),
-    application:set_env(?APP, App, lists:keyreplace(Key, 1, Env, {Key, Value})),
-    " successfully\n".
+%% session_config_callback([_, AppStr, KeyStr], Value) ->
+%%     session_config_callback(l2a(AppStr), l2a(KeyStr), Value).
+%% session_config_callback(App, Key, Value) ->
+%%     {ok, Env} = emqx:env(App),
+%%     application:set_env(?APP, App, lists:keyreplace(Key, 1, Env, {Key, Value})),
+%%     " successfully\n".
 
 l2a(List) -> list_to_atom(List).
 
@@ -287,43 +288,43 @@ l2a(List) -> list_to_atom(List).
 %% MQTT MQueue
 %%--------------------------------------------------------------------
 
-register_queue_formatter() ->
-    ConfigKeys = ["type", 
-                  "priority",
-                  "max_length",
-                  "low_watermark",
-                  "high_watermark",
-                  "store_qos0"],
-    [clique:register_formatter(["mqtt", "mqueue", Key], fun queue_formatter_callback/2) || Key <- ConfigKeys].
+%% register_queue_formatter() ->
+%%     ConfigKeys = ["type", 
+%%                   "priority",
+%%                   "max_length",
+%%                   "low_watermark",
+%%                   "high_watermark",
+%%                   "store_qos0"],
+%%     [clique:register_formatter(["mqtt", "mqueue", Key], fun queue_formatter_callback/2) || Key <- ConfigKeys].
 
-queue_formatter_callback([_, _, Key], Params) ->
-    proplists:get_value(list_to_atom(Key), Params).
+%% queue_formatter_callback([_, _, Key], Params) ->
+%%     proplists:get_value(list_to_atom(Key), Params).
 
-register_queue_config() ->
-    ConfigKeys = ["mqtt.mqueue.type",
-                  "mqtt.mqueue.priority",
-                  "mqtt.mqueue.max_length",
-                  "mqtt.mqueue.low_watermark",
-                  "mqtt.mqueue.high_watermark",
-                  "mqtt.mqueue.store_qos0"],
-    [clique:register_config(Key , fun queue_config_callback/2) || Key <- ConfigKeys],
-    ok = register_config_whitelist(ConfigKeys).
+%% register_queue_config() ->
+%%     ConfigKeys = ["mqtt.mqueue.type",
+%%                   "mqtt.mqueue.priority",
+%%                   "mqtt.mqueue.max_length",
+%%                   "mqtt.mqueue.low_watermark",
+%%                   "mqtt.mqueue.high_watermark",
+%%                   "mqtt.mqueue.store_qos0"],
+%%     [clique:register_config(Key , fun queue_config_callback/2) || Key <- ConfigKeys],
+%%     ok = register_config_whitelist(ConfigKeys).
 
-queue_config_callback([_, AppStr, KeyStr], Value) ->
-    queue_config_callback(l2a(AppStr), l2a(KeyStr), Value).
+%% queue_config_callback([_, AppStr, KeyStr], Value) ->
+%%     queue_config_callback(l2a(AppStr), l2a(KeyStr), Value).
 
-queue_config_callback(App, low_watermark, Value) ->
-    {ok, Env} = emqx:env(App),
-    application:set_env(?APP, App, lists:keyreplace(low_watermark, 1, Env, {low_watermark, Value})),
-    " successfully\n";
-queue_config_callback(App, high_watermark, Value) ->
-    {ok, Env} = emqx:env(App),
-    application:set_env(?APP, App, lists:keyreplace(high_watermark, 1, Env, {high_watermark, Value})),
-    " successfully\n";
-queue_config_callback(App, Key, Value) ->
-    {ok, Env} = emqx:env(App),
-    application:set_env(?APP, App, lists:keyreplace(Key, 1, Env, {Key, Value})),
-    " successfully\n".
+%% queue_config_callback(App, low_watermark, Value) ->
+%%     {ok, Env} = emqx:env(App),
+%%     application:set_env(?APP, App, lists:keyreplace(low_watermark, 1, Env, {low_watermark, Value})),
+%%     " successfully\n";
+%% queue_config_callback(App, high_watermark, Value) ->
+%%     {ok, Env} = emqx:env(App),
+%%     application:set_env(?APP, App, lists:keyreplace(high_watermark, 1, Env, {high_watermark, Value})),
+%%     " successfully\n";
+%% queue_config_callback(App, Key, Value) ->
+%%     {ok, Env} = emqx:env(App),
+%%     application:set_env(?APP, App, lists:keyreplace(Key, 1, Env, {Key, Value})),
+%%     " successfully\n".
 
 %%--------------------------------------------------------------------
 %% MQTT Broker
@@ -331,8 +332,8 @@ queue_config_callback(App, Key, Value) ->
 
 register_broker_config() ->
     ConfigKeys = ["mqtt.broker.sys_interval"],
-    [clique:register_config(Key , fun broker_config_callback/2) || Key <- ConfigKeys],
-    ok = register_config_whitelist(ConfigKeys).
+    [clique:register_config(Key , fun broker_config_callback/2) || Key <- ConfigKeys].
+    %% ok = register_config_whitelist(ConfigKeys).
 
 broker_config_callback([_, KeyStr0, KeyStr1], Value) ->
     KeyStr = lists:concat([KeyStr0, "_", KeyStr1]),
@@ -343,24 +344,24 @@ broker_config_callback([_, KeyStr0, KeyStr1], Value) ->
 %% MQTT Lager
 %%--------------------------------------------------------------------
 
-register_lager_formatter() ->
-    ConfigKeys = ["level"],
-    [clique:register_formatter(["log", "console", Key], fun lager_formatter_callback/2) || Key <- ConfigKeys].
+%% register_lager_formatter() ->
+%%     ConfigKeys = ["level"],
+%%     [clique:register_formatter(["log", "console", Key], fun lager_formatter_callback/2) || Key <- ConfigKeys].
 
-lager_formatter_callback(_, Params) ->
-    proplists:get_value(lager_console_backend, Params).
+%% lager_formatter_callback(_, Params) ->
+%%     proplists:get_value(lager_console_backend, Params).
 
-register_lager_config() ->
-    ConfigKeys = ["log.console.level"],
-    [clique:register_config(Key , fun lager_config_callback/2) || Key <- ConfigKeys],
-    ok = register_config_whitelist(ConfigKeys).
+%% register_lager_config() ->
+%%     ConfigKeys = ["log.console.level"],
+%%     [clique:register_config(Key , fun lager_config_callback/2) || Key <- ConfigKeys],
+%%     ok = register_config_whitelist(ConfigKeys).
 
-lager_config_callback(_, Value) ->
-    lager:set_loglevel(lager_console_backend, Value),
-    " successfully\n".
+%% lager_config_callback(_, Value) ->
+%%     lager:set_loglevel(lager_console_backend, Value),
+%%     " successfully\n".
 
-register_config_whitelist(ConfigKeys) ->
-  clique:register_config_whitelist(ConfigKeys, ?APP).
+%% register_config_whitelist(ConfigKeys) ->
+%%   clique:register_config_whitelist(ConfigKeys, ?APP).
 
 %%--------------------------------------------------------------------
 %% Inner Function

--- a/test/emqx_mgmt_api_SUITE.erl
+++ b/test/emqx_mgmt_api_SUITE.erl
@@ -1,6 +1,21 @@
+%% Copyright (c) 2013-2019 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
 -module(emqx_mgmt_api_SUITE).
 
 -compile(export_all).
+-compile(nowarn_export_all).
 
 -include_lib("eunit/include/eunit.hrl").
 
@@ -19,66 +34,36 @@ all() ->
     [{group, rest_api}].
 
 groups() ->
-    [{rest_api, [sequence], [alarms,
-                             apps,
-                             banned,
-                             brokers,
-                             configs,
-                             connections_and_sessions,
-                             listeners,
-                             metrics,
-                             nodes,
-                             plugins,
-                             pubsub,
-                             routes_and_subscriptions,
-                             stats]}].
+    [{rest_api,
+      [sequence], 
+      [alarms,
+       apps,
+       banned,
+       brokers,
+       configs,
+       connections_and_sessions,
+       listeners,
+       metrics,
+       nodes,
+       plugins,
+       pubsub,
+       routes_and_subscriptions,
+       stats]}].
+
+apps() ->
+    [emqx, emqx_management, emqx_reloader].
 
 init_per_suite(Config) ->
     application:load(emqx_reloader),
-    [start_apps(App, {SchemaFile, ConfigFile}) ||
-        {App, SchemaFile, ConfigFile}
-            <- [{emqx, local_path("deps/emqx/priv/emqx.schema"),
-                       local_path("deps/emqx/etc/emqx.conf")},
-                {emqx_management, local_path("priv/emqx_management.schema"),
-                                  local_path("etc/emqx_management.conf")},
-                {emqx_reloader, local_path("deps/emqx_reloader/priv/emqx_reloader.schema"),
-                                  local_path("deps/emqx_reloader/etc/emqx_reloader.conf")}]],
+    emqx_mgmt_helper:start_apps(apps()),
     ekka_mnesia:start(),
     emqx_mgmt_auth:mnesia(boot),
     emqx_mgmt_auth:add_app(<<"myappid">>, <<"test">>),
     Config.
 
 end_per_suite(_Config) ->
-    [application:stop(App) || App <- [emqx_reloader, emqx_management, emqx]],
+    emqx_mgmt_helper:stop_apps(apps()),
     ekka_mnesia:ensure_stopped().
-
-get_base_dir() ->
-    {file, Here} = code:is_loaded(?MODULE),
-    filename:dirname(filename:dirname(Here)).
-
-local_path(RelativePath) ->
-    filename:join([get_base_dir(), RelativePath]).
-
-start_apps(App, {SchemaFile, ConfigFile}) ->
-    read_schema_configs(App, {SchemaFile, ConfigFile}),
-    set_special_configs(App),
-    application:ensure_all_started(App).
-
-read_schema_configs(App, {SchemaFile, ConfigFile}) ->
-    ct:pal("Read configs - SchemaFile: ~p, ConfigFile: ~p", [SchemaFile, ConfigFile]),
-    Schema = cuttlefish_schema:files([SchemaFile]),
-    Conf = conf_parse:file(ConfigFile),
-    NewConfig = cuttlefish_generator:map(Schema, Conf),
-    Vals = proplists:get_value(App, NewConfig, []),
-    [application:set_env(App, Par, Value) || {Par, Value} <- Vals].
-
-set_special_configs(emqx) ->
-    application:set_env(emqx, plugins_loaded_file,
-                        local_path("deps/emqx/test/emqx_SUITE_data/loaded_plugins")),
-    PluginsEtcDir = local_path("deps/emqx_reloader/etc/") ++ "/",
-    application:set_env(emqx, plugins_etc_dir, PluginsEtcDir);
-set_special_configs(_App) ->
-    ok.
 
 batch_connect(NumberOfConnections) ->
     batch_connect([], NumberOfConnections).

--- a/test/emqx_mgmt_helper.erl
+++ b/test/emqx_mgmt_helper.erl
@@ -1,0 +1,65 @@
+%% Copyright (c) 2013-2019 EMQ Technologies Co., Ltd. All Rights Reserved.
+%%
+%% Licensed under the Apache License, Version 2.0 (the "License");
+%% you may not use this file except in compliance with the License.
+%% You may obtain a copy of the License at
+%%
+%%     http://www.apache.org/licenses/LICENSE-2.0
+%%
+%% Unless required by applicable law or agreed to in writing, software
+%% distributed under the License is distributed on an "AS IS" BASIS,
+%% WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+%% See the License for the specific language governing permissions and
+%% limitations under the License.
+
+-module(emqx_mgmt_helper).
+
+-compile(export_all).
+-compile(nowarn_export_all).
+
+start_apps([]) ->
+    ok;
+start_apps([emqx_management | LeftApps]) ->
+    start_app(emqx_management, local_path("priv/emqx_management.schema"), 
+                               local_path("etc/emqx_management.conf")),
+    start_apps(LeftApps);
+start_apps([App | LeftApps]) ->
+    SchemaFile = deps_path(App, "priv/" ++ atom_to_list(App) ++ ".schema"),
+    ConfigFile = deps_path(App, "etc/" ++ atom_to_list(App) ++ ".conf"),
+    start_app(App, SchemaFile, ConfigFile),
+    start_apps(LeftApps).
+
+stop_apps(Apps) ->
+    [application:stop(App) || App <- Apps].
+
+start_app(App, SchemaFile, ConfigFile) ->
+    read_schema_configs(App, SchemaFile, ConfigFile),
+    set_special_configs(App),
+    application:ensure_all_started(App).
+
+local_path(RelativePath) ->
+    deps_path(emqx_management, RelativePath).
+
+deps_path(App, RelativePath) ->
+    %% Note: not lib_dir because etc dir is not sym-link-ed to _build dir
+    %% but priv dir is
+    Path0 = code:priv_dir(App),
+    Path = case file:read_link(Path0) of
+               {ok, Resolved} -> Resolved;
+               {error, _} -> Path0
+           end,
+    filename:join([Path, "..", RelativePath]).
+
+read_schema_configs(App, SchemaFile, ConfigFile) ->
+    ct:pal("Read configs - SchemaFile: ~p, ConfigFile: ~p", [SchemaFile, ConfigFile]),
+    Schema = cuttlefish_schema:files([SchemaFile]),
+    Conf = conf_parse:file(ConfigFile),
+    NewConfig = cuttlefish_generator:map(Schema, Conf),
+    Vals = proplists:get_value(App, NewConfig, []),
+    [application:set_env(App, Par, Value) || {Par, Value} <- Vals].
+
+set_special_configs(emqx) ->
+    PluginsEtcDir = deps_path(emqx_reloader, "etc/"),
+    application:set_env(emqx, plugins_etc_dir, PluginsEtcDir);
+set_special_configs(_App) ->
+    ok.

--- a/test/emqx_mgmt_helper.erl
+++ b/test/emqx_mgmt_helper.erl
@@ -17,15 +17,18 @@
 -compile(export_all).
 -compile(nowarn_export_all).
 
+-import(filename, [join/1]).
+
 start_apps([]) ->
     ok;
 start_apps([emqx_management | LeftApps]) ->
-    start_app(emqx_management, local_path("priv/emqx_management.schema"), 
-                               local_path("etc/emqx_management.conf")),
+    start_app(emqx_management,
+              local_path(join(["priv", "emqx_management.schema"])),
+              local_path(join(["etc", "emqx_management.conf"]))),
     start_apps(LeftApps);
 start_apps([App | LeftApps]) ->
-    SchemaFile = deps_path(App, "priv/" ++ atom_to_list(App) ++ ".schema"),
-    ConfigFile = deps_path(App, "etc/" ++ atom_to_list(App) ++ ".conf"),
+    SchemaFile = deps_path(App, join(["priv", atom_to_list(App) ++ ".schema"])),
+    ConfigFile = deps_path(App, join(["etc", atom_to_list(App) ++ ".conf"])),
     start_app(App, SchemaFile, ConfigFile),
     start_apps(LeftApps).
 


### PR DESCRIPTION
Prior to this change, travis-CI always run failed because the
init_per_suite function is not compatible with rebar and there are too
many undefined or unused functions in emqx_management.
This change fix these problems