### PR TITLE
Load all plugins API

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ PROJECT_DESCRIPTION = EMQ X Management API and CLI
 PROJECT_MOD = emqx_mgmt_app
 
 DEPS = minirest clique
-dep_minirest = git-emqx https://github.com/emqx/minirest v0.1.0
+dep_minirest = git-emqx https://github.com/emqx/minirest v0.2.0
 dep_clique   = git-emqx https://github.com/emqx/clique v0.3.11
 
 LOCAL_DEPS = mnesia

--- a/src/emqx_mgmt_http.erl
+++ b/src/emqx_mgmt_http.erl
@@ -22,8 +22,10 @@
 
 -export([init/2]).
 
--define(APP, emqx_management).
+-include_lib("emqx/include/emqx.hrl").
 
+-define(APP, emqx_management).
+-define(EXCEPT_PLUGIN, [emqx_dashboard]).
 -ifdef(TEST).
 -define(EXCEPT, []).
 -else.
@@ -60,7 +62,8 @@ listener_name(Proto) ->
     list_to_atom(atom_to_list(Proto) ++ ":management").
 
 http_handlers() ->
-    [{"/api/v3", minirest:handler(#{apps => [?APP], except => ?EXCEPT }),
+    Plugins = lists:map(fun(Plugin) -> Plugin#plugin.name end, emqx_plugins:list()),
+    [{"/api/v3", minirest:handler(#{apps => Plugins -- ?EXCEPT_PLUGIN, except => ?EXCEPT }),
                  [{authorization, fun authorize_appid/1}]}].
 
 %%--------------------------------------------------------------------

--- a/src/emqx_mgmt_http.erl
+++ b/src/emqx_mgmt_http.erl
@@ -63,8 +63,8 @@ listener_name(Proto) ->
 
 http_handlers() ->
     Plugins = lists:map(fun(Plugin) -> Plugin#plugin.name end, emqx_plugins:list()),
-    [{"/api/v3", minirest:handler(#{apps     => Plugins -- ?EXCEPT_PLUGIN,
-                                    except   => ?EXCEPT,
+    [{"/api/v3", minirest:handler(#{apps   => Plugins -- ?EXCEPT_PLUGIN,
+                                    except => ?EXCEPT,
                                     filter => fun filter/1}),
                  [{authorization, fun authorize_appid/1}]}].
 

--- a/src/emqx_mgmt_http.erl
+++ b/src/emqx_mgmt_http.erl
@@ -65,7 +65,7 @@ http_handlers() ->
     Plugins = lists:map(fun(Plugin) -> Plugin#plugin.name end, emqx_plugins:list()),
     [{"/api/v3", minirest:handler(#{apps     => Plugins -- ?EXCEPT_PLUGIN,
                                     except   => ?EXCEPT,
-                                    validate => fun validate/1}),
+                                    filter => fun filter/1}),
                  [{authorization, fun authorize_appid/1}]}].
 
 %%--------------------------------------------------------------------
@@ -97,7 +97,7 @@ authorize_appid(Req) ->
          _  -> false
     end.
 
-validate(#{app := App}) ->
+filter(#{app := App}) ->
     case emqx_plugins:find_plugin(App) of
         false -> false;
         Plugin -> Plugin#plugin.active


### PR DESCRIPTION
By adding the -rest_api attribute to the module
The plugin can execute the plugin function via the HTTP API
As follows:

curl http://localhost:8080/api/v3/emqx_plugin_xxx_api/path

```
-module(emqx_plugin_xxx_api).

-rest_api(#{name   => api_name,
            method => 'GET'| 'POST' | 'PUT' | 'DELETE',
            path   => "plugin_name/path" | "plugin_name/path/:bin:id",
            func   => callback_funtion_name,
            descr  => "API description"}).

-export([callback_function_name/2]).

## Bindings
## If path plugin_name/path/:bin:id
## Bindings is #{id := Id}
## Params is request params
callback_function_name(Bindings, Params) ->
    {ok, [{code, 0}]}.
```