### PR TITLE
feature(logger): support starting and stopping log handlers

### DIFF
--- a/test/emqx_mgmt_SUITE.erl
+++ b/test/emqx_mgmt_SUITE.erl
@@ -106,7 +106,7 @@ t_log_cmd(_) ->
                          ?assertEqual(Level++"\n", emqx_mgmt_cli:log(["handlers", "set-level",
                                                                       atom_to_list(Id), Level]))
                       end, ?LOG_LEVELS)
-        || {Id, _Level, _Dst} <- emqx_logger:get_log_handlers()].
+        || #{id := Id} <- emqx_logger:get_log_handlers()].
 
 t_mgmt_cmd(_) ->
     ct:pal("start testing the mgmt command"),


### PR DESCRIPTION
This PR added the support for adding and stopping a log handler. It is useful when the output of default log handler (logging to the emqx console) is messing the user's input, and he want to stop it.

- emqx log handlers start <HandlerID> 
- emqx log handlers stop <HandlerID> 