### PR TITLE
fix(api): convert anonymous funcs to M:F

### DIFF
--- a/src/emqx_mgmt.erl
+++ b/src/emqx_mgmt.erl
@@ -299,15 +299,15 @@ lookup_client({clientid, ClientId}, FormatFun) ->
 lookup_client({username, Username}, FormatFun) ->
     lists:append([lookup_client(Node, {username, Username}, FormatFun) || Node <- ekka_mnesia:running_nodes()]).
 
-lookup_client(Node, {clientid, ClientId}, FormatFun) when Node =:= node() ->
-    FormatFun(ets:lookup(emqx_channel, ClientId));
+lookup_client(Node, {clientid, ClientId}, {M,F}) when Node =:= node() ->
+    M:F(ets:lookup(emqx_channel, ClientId));
 
 lookup_client(Node, {clientid, ClientId}, FormatFun) ->
     rpc_call(Node, lookup_client, [Node, {clientid, ClientId}, FormatFun]);
 
-lookup_client(Node, {username, Username}, FormatFun) when Node =:= node() ->
+lookup_client(Node, {username, Username}, {M,F}) when Node =:= node() ->
     MatchSpec = [{{'$1', #{clientinfo => #{username => '$2'}}, '_'}, [{'=:=','$2', Username}], ['$1']}],
-    FormatFun(ets:select(emqx_channel_info, MatchSpec));
+    M:F(ets:select(emqx_channel_info, MatchSpec));
 
 lookup_client(Node, {username, Username}, FormatFun) ->
     rpc_call(Node, lookup_client, [Node, {username, Username}, FormatFun]).
@@ -389,9 +389,9 @@ list_subscriptions(Node) ->
 list_subscriptions_via_topic(Topic, FormatFun) ->
     lists:append([list_subscriptions_via_topic(Node, Topic, FormatFun) || Node <- ekka_mnesia:running_nodes()]).
 
-list_subscriptions_via_topic(Node, Topic, FormatFun) when Node =:= node() ->
+list_subscriptions_via_topic(Node, Topic, {M,F}) when Node =:= node() ->
     MatchSpec = [{{{'_', '$1'}, '_'}, [{'=:=','$1', Topic}], ['$_']}],
-    FormatFun(ets:select(emqx_suboption, MatchSpec));
+    M:F(ets:select(emqx_suboption, MatchSpec));
 
 list_subscriptions_via_topic(Node, {topic, Topic}, FormatFun) ->
     rpc_call(Node, list_subscriptions_via_topic, [Node, {topic, Topic}, FormatFun]).

--- a/src/emqx_mgmt_api.erl
+++ b/src/emqx_mgmt_api.erl
@@ -91,8 +91,8 @@ node_query(Node, Params, {Tab, QsSchema}, QueryFun) ->
     #{meta => NMeta, data => lists:sublist(Rows, Limit)}.
 
 %% @private
-do_query(Node, Qs, QueryFun, Start, Limit) when Node =:= node() ->
-    QueryFun(Qs, Start, Limit);
+do_query(Node, Qs, {M,F}, Start, Limit) when Node =:= node() ->
+    M:F(Qs, Start, Limit);
 do_query(Node, Qs, QueryFun, Start, Limit) ->
     rpc_call(Node, ?MODULE, do_query, [Node, Qs, QueryFun, Start, Limit], 50000).
 

--- a/src/emqx_mgmt_api_clients.erl
+++ b/src/emqx_mgmt_api_clients.erl
@@ -108,11 +108,18 @@
         , list_acl_cache/2
         ]).
 
+-export([ query/3
+        , format/1
+        ]).
+
+-define(query_fun, {?MODULE, query}).
+-define(format_fun, {?MODULE, format}).
+
 list(Bindings, Params) when map_size(Bindings) == 0 ->
-    return({ok, emqx_mgmt_api:cluster_query(Params, ?CLIENT_QS_SCHEMA, fun query/3)});
+    return({ok, emqx_mgmt_api:cluster_query(Params, ?CLIENT_QS_SCHEMA, ?query_fun)});
 
 list(#{node := Node}, Params) when Node =:= node() ->
-    return({ok, emqx_mgmt_api:node_query(Node, Params, ?CLIENT_QS_SCHEMA, fun query/3)});
+    return({ok, emqx_mgmt_api:node_query(Node, Params, ?CLIENT_QS_SCHEMA, ?query_fun)});
 
 list(Bindings = #{node := Node}, Params) ->
     case rpc:call(Node, ?MODULE, list, [Bindings, Params]) of
@@ -121,16 +128,16 @@ list(Bindings = #{node := Node}, Params) ->
     end.
 
 lookup(#{node := Node, clientid := ClientId}, _Params) ->
-    return({ok, emqx_mgmt:lookup_client(Node, {clientid, emqx_mgmt_util:urldecode(ClientId)}, fun format/1)});
+    return({ok, emqx_mgmt:lookup_client(Node, {clientid, emqx_mgmt_util:urldecode(ClientId)}, ?format_fun)});
 
 lookup(#{clientid := ClientId}, _Params) ->
-    return({ok, emqx_mgmt:lookup_client({clientid, emqx_mgmt_util:urldecode(ClientId)}, fun format/1)});
+    return({ok, emqx_mgmt:lookup_client({clientid, emqx_mgmt_util:urldecode(ClientId)}, ?format_fun)});
 
 lookup(#{node := Node, username := Username}, _Params) ->
-    return({ok, emqx_mgmt:lookup_client(Node, {username, emqx_mgmt_util:urldecode(Username)}, fun format/1)});
+    return({ok, emqx_mgmt:lookup_client(Node, {username, emqx_mgmt_util:urldecode(Username)}, ?format_fun)});
 
 lookup(#{username := Username}, _Params) ->
-    return({ok, emqx_mgmt:lookup_client({username, emqx_mgmt_util:urldecode(Username)}, fun format/1)}).
+    return({ok, emqx_mgmt:lookup_client({username, emqx_mgmt_util:urldecode(Username)}, ?format_fun)}).
 
 kickout(#{clientid := ClientId}, _Params) ->
     case emqx_mgmt:kickout_client(emqx_mgmt_util:urldecode(ClientId)) of

--- a/src/emqx_mgmt_api_subscriptions.erl
+++ b/src/emqx_mgmt_api_subscriptions.erl
@@ -55,12 +55,19 @@
         , lookup/2
         ]).
 
+-export([ query/3
+        , format/1
+        ]).
+
+-define(query_fun, {?MODULE, query}).
+-define(format_fun, {?MODULE, format}).
+
 list(Bindings, Params) when map_size(Bindings) == 0 ->
     case proplists:get_value(<<"topic">>, Params) of
         undefined ->
-            return({ok, emqx_mgmt_api:cluster_query(Params, ?SUBS_QS_SCHEMA, fun query/3)});
+            return({ok, emqx_mgmt_api:cluster_query(Params, ?SUBS_QS_SCHEMA, ?query_fun)});
         Topic ->
-            return({ok, emqx_mgmt:list_subscriptions_via_topic(emqx_mgmt_util:urldecode(Topic), fun format/1)})
+            return({ok, emqx_mgmt:list_subscriptions_via_topic(emqx_mgmt_util:urldecode(Topic), ?format_fun)})
     end;
 
 list(#{node := Node} = Bindings, Params) ->
@@ -68,7 +75,7 @@ list(#{node := Node} = Bindings, Params) ->
         undefined ->
             case Node =:= node() of
                 true ->
-                    return({ok, emqx_mgmt_api:node_query(Node, Params, ?SUBS_QS_SCHEMA, fun query/3)});
+                    return({ok, emqx_mgmt_api:node_query(Node, Params, ?SUBS_QS_SCHEMA, ?query_fun)});
                 false ->
                     case rpc:call(Node, ?MODULE, list, [Bindings, Params]) of
                         {badrpc, Reason} -> return({error, Reason});
@@ -76,7 +83,7 @@ list(#{node := Node} = Bindings, Params) ->
                     end
             end;
         Topic ->
-            return({ok, emqx_mgmt:list_subscriptions_via_topic(Node, emqx_mgmt_util:urldecode(Topic), fun format/1)})
+            return({ok, emqx_mgmt:list_subscriptions_via_topic(Node, emqx_mgmt_util:urldecode(Topic), ?format_fun)})
     end.
 
 lookup(#{node := Node, clientid := ClientId}, _Params) ->


### PR DESCRIPTION
Anonymous functions would crash with error `badfun` if the code has been changed. Especially the anonymous functions is sent to processes in a message, passed as an argument of an RPC call, or stored in ETS tables.

For anonymous funcs in RPC calls and messages, we could change it to equivalent M:F:A calls.

For those stored in ETS tables, we could rebuild it when the exception arises.