### PR TITLE
add restart and stop to listener commands of emqx_ctl

### DIFF
--- a/src/emqx_mgmt.erl
+++ b/src/emqx_mgmt.erl
@@ -567,11 +567,7 @@ list_listeners(Node) ->
     rpc_call(Node, list_listeners, [Node]).
 
 restart_listener(Proto, ListenOn) ->
-    ListenOn1 = case string:tokens(ListenOn, ":") of
-        [Port]     -> list_to_integer(Port);
-        [IP, Port] -> {IP, list_to_integer(Port)}
-    end,
-    case find_listener_opts(Proto, ListenOn1) of
+    case find_listener_opts(Proto, ListenOn) of
         {ok, Listener} ->
             emqx_listeners:restart_listener(Listener);
         {error, Error} ->
@@ -579,11 +575,7 @@ restart_listener(Proto, ListenOn) ->
     end.
 
 restart_listener(Node, Proto, ListenOn) when Node =:= node() ->
-    ListenOn1 = case string:tokens(ListenOn, ":") of
-        [Port]     -> list_to_integer(Port);
-        [IP, Port] -> {IP, list_to_integer(Port)}
-    end,
-    case find_listener_opts(Proto, ListenOn1) of
+    case find_listener_opts(Proto, ListenOn) of
         {ok, Listener} ->
             emqx_listeners:restart_listener(Listener);
         {error, Error} ->
@@ -595,14 +587,32 @@ restart_listener(Node, Proto, ListenOn) ->
 
 find_listener_opts(Proto, ListenOn) ->
     ProtoAtom = list_to_atom(Proto),
-    foldl(fun({LisProtocol, LisListenOn, LisOpts}, Acc) ->
-        if
-        LisProtocol == ProtoAtom andalso LisListenOn == ListenOn ->
-            {ok, {LisProtocol, LisListenOn, LisOpts}};
-        true ->
-            Acc
-        end
-    end, {error, "Listener/options not found"}, emqx:get_env(listeners, [])).
+    case parse_listenon(ListenOn) of
+        {ok, ListenOnParsed} ->
+            foldl(fun({LisProtocol, LisListenOn, LisOpts}, Acc) ->
+                if
+                LisProtocol == ProtoAtom andalso LisListenOn == ListenOnParsed ->
+                    {ok, {LisProtocol, LisListenOn, LisOpts}};
+                true ->
+                    Acc
+                end
+            end, {error, "Listener/options not found"}, emqx:get_env(listeners, []));
+        {error, Error} ->
+            {error, Error}
+    end.
+
+parse_listenon(ListenOn) ->
+    case string:tokens(ListenOn, ":") of
+        [] ->
+            {error, "missing port"};
+        [Port] ->
+            {ok, list_to_integer(Port)};
+        [IP, Port] ->
+            case inet:parse_address(IP) of
+                {ok, IP1}      -> {ok, {IP1, list_to_integer(Port)}};
+                {error, Error} -> {error, Error}
+            end
+    end.
 
 %%--------------------------------------------------------------------
 %% Get Alarms
@@ -973,3 +983,19 @@ action_to_prop_list({action_instance, ActionInstId, Name, FallbackActions, Args}
      {name, Name},
      {fallbacks, actions_to_prop_list(FallbackActions)},
      {args, Args}].
+
+%%--------------------------------------------------------------------
+%% EUnits
+%%--------------------------------------------------------------------
+
+-ifdef(TEST).
+-include_lib("eunit/include/eunit.hrl").
+
+parse_listenon_test() ->
+    ?assertEqual({ok, 8883}, parse_listenon("8883")),
+    ?assertEqual({ok, 8883}, parse_listenon(":8883")),
+    ?assertEqual({ok, {{127,0,0,1},8883}}, parse_listenon("127.0.0.1:8883")),
+    ?assertEqual({error, "missing port"}, parse_listenon("")),
+    ?assertEqual({error, einval}, parse_listenon("localhost:8883")).
+
+-endif.

--- a/src/emqx_mgmt_api_listeners.erl
+++ b/src/emqx_mgmt_api_listeners.erl
@@ -30,7 +30,19 @@
             func   => list,
             descr  => "A list of listeners on the node"}).
 
--export([list/2]).
+-rest_api(#{name   => restart_listener,
+            method => 'PUT',
+            path   => "/listeners/:bin:proto/:bin:port/restart",
+            func   => restart,
+            descr  => "Restart a listener in the cluster"}).
+
+-rest_api(#{name   => restart_node_listener,
+            method => 'PUT',
+            path   => "/nodes/:atom:node/listeners/:bin:proto/:bin:port/restart",
+            func   => restart,
+            descr  => "Restart a listener in the cluster"}).
+
+-export([list/2, restart/2]).
 
 %% List listeners on a node.
 list(#{node := Node}, _Params) ->
@@ -40,6 +52,23 @@ list(#{node := Node}, _Params) ->
 list(_Binding, _Params) ->
     return({ok, [#{node => Node, listeners => format(Listeners)}
                               || {Node, Listeners} <- emqx_mgmt:list_listeners()]}).
+
+%% Restart listeners on a node.
+restart(#{node := Node, proto := Proto, port := Port}, _Params) ->
+    case emqx_mgmt:restart_listener(Node, binary_to_list(Proto), binary_to_list(Port)) of
+        {ok, _} -> return({ok, "Listener restarted."});
+        {err, Error} -> return({err, Error})
+    end;
+
+%% Restart listeners in the cluster.
+restart(#{proto := Proto, port := Port}, _Params) ->
+    Results = [emqx_mgmt:restart_listener(Node, binary_to_list(Proto), binary_to_list(Port)) || {Node, _Info} <- emqx_mgmt:list_nodes()],
+    case lists:filter(fun(Item) -> Item =/= ok end, Results) of
+        [] ->
+            return(ok);
+        Errors ->
+            return(lists:last(Errors))
+    end.
 
 format(Listeners) when is_list(Listeners) ->
     [ Info#{listen_on => list_to_binary(esockd:to_string(ListenOn))}

--- a/src/emqx_mgmt_cli.erl
+++ b/src/emqx_mgmt_cli.erl
@@ -550,9 +550,19 @@ listeners(["stop", Proto, ListenOn]) ->
             emqx_ctl:print("Failed to stop ~s listener on ~s, error:~p~n", [Proto, ListenOn, Error])
     end;
 
+listeners(["restart", Proto, ListenOn]) ->
+    case emqx_mgmt:restart_listener(Proto, ListenOn) of
+        ok ->
+            emqx_ctl:print("Restarted ~s listener on ~s successfully.~n", [Proto, ListenOn]);
+        {error, Error} ->
+            emqx_ctl:print("Failed to restart ~s listener on ~s, error:~p~n", [Proto, ListenOn, Error])
+    end;
+
 listeners(_) ->
     emqx_ctl:usage([{"listeners",                        "List listeners"},
-                    {"listeners stop    <Proto> <Port>", "Stop a listener"}]).
+                    {"listeners stop    <Proto> <Port>", "Stop a listener"},
+                    {"listeners start   <Proto> <Port>", "Start a listener"},
+                    {"listeners restart <Proto> <Port>", "Restart a listener"}]).
 
 %%--------------------------------------------------------------------
 %% @doc data Command

--- a/src/emqx_mgmt_cli.erl
+++ b/src/emqx_mgmt_cli.erl
@@ -552,7 +552,7 @@ listeners(["stop", Proto, ListenOn]) ->
 
 listeners(["restart", Proto, ListenOn]) ->
     case emqx_mgmt:restart_listener(Proto, ListenOn) of
-        ok ->
+        {ok, _} ->
             emqx_ctl:print("Restarted ~s listener on ~s successfully.~n", [Proto, ListenOn]);
         {error, Error} ->
             emqx_ctl:print("Failed to restart ~s listener on ~s, error:~p~n", [Proto, ListenOn, Error])
@@ -560,8 +560,6 @@ listeners(["restart", Proto, ListenOn]) ->
 
 listeners(_) ->
     emqx_ctl:usage([{"listeners",                        "List listeners"},
-                    {"listeners stop    <Proto> <Port>", "Stop a listener"},
-                    {"listeners start   <Proto> <Port>", "Start a listener"},
                     {"listeners restart <Proto> <Port>", "Restart a listener"}]).
 
 %%--------------------------------------------------------------------

--- a/test/emqx_mgmt_SUITE.erl
+++ b/test/emqx_mgmt_SUITE.erl
@@ -242,7 +242,8 @@ t_subscriptions_cmd(_) ->
 t_listeners_cmd(_) ->
     print_mock(),
     ?assertEqual(emqx_mgmt_cli:listeners([]), ok),
-    ?assertEqual(emqx_mgmt_cli:listeners(["stop", "wss", "8084"]), "Stop wss listener on 8084 successfully.\n").
+    ?assertEqual(emqx_mgmt_cli:listeners(["stop", "wss", "8084"]), "Stop wss listener on 8084 successfully.\n"),
+    ?assertEqual(emqx_mgmt_cli:listeners(["restart", "wss", "8084"]), "Restarted wss listener on 8084 successfully.\n").
 
 t_plugins_cmd(_) ->
     print_mock(),


### PR DESCRIPTION
`emqx_ctl` already has `stop`. This patch adds the complementary `start` and `restart` commands.

Example:
```
emqx_ctl listener restart ssl 8883
```
